### PR TITLE
Allow all kinds of text in task 3 regex

### DIFF
--- a/scripts/oppgave3.js
+++ b/scripts/oppgave3.js
@@ -12,7 +12,7 @@
 
 
 module.exports = function (robot) {
-  robot.respond(/hvem av (\w+) har jeg hooket med sist/, function (res) {
+  robot.respond(/hvem av (.*) har jeg hooket med sist/, function (res) {
     // res.match[1] -- henter ut ordet på plassen til (\w+) i det du skrev til botten. (\w+) er en regexp
 
     // code here


### PR DESCRIPTION
Sidan oppgåva seier dette:
```
hubot hvem av guttene har jeg hooket med sist? - botten svarer et tilfeldig guttenavn
hubot hvem av jentene har jeg hooket med sist? - botten svarer et tilfeldig jentenavn
hubot hvem av ...  har jeg hooket med sist?- botten svarer en tilfeldig person
```
burde det vere lov å skrive ordrett "hubot hvem av ...  har jeg hooket med sist?"